### PR TITLE
fix: Lack of node_modules/electron-audio-loopback/dist/types.js declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "electron-audio-loopback",
-  "version": "1.0.6",
+  "name": "electron-audio-loopback-josh",
+  "version": "1.0.7",
   "description": "Capture system audio loopback on macOS 12.3+, Windows 10+ and Linux",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,8 @@
     "prepublishOnly": "npm run clean && npm run build",
     "test": "npm run build && electron example/index.js",
     "lint": "eslint src --ext .ts",
-    "lint:fix": "eslint src --ext .ts --fix"
+    "lint:fix": "eslint src --ext .ts --fix",
+    "postbuild": "copy src\\types.d.ts dist\\types.d.ts"
   },
   "keywords": [
     "electron",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "electron-audio-loopback-josh",
-  "version": "1.0.7",
+  "name": "electron-audio-loopback",
+  "version": "1.0.6",
   "description": "Capture system audio loopback on macOS 12.3+, Windows 10+ and Linux",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
When try to complie with electron, it will show:
```bash
> tsc -p tsconfig.electron.json

node_modules/electron-audio-loopback/dist/main.d.ts:1:38 - error TS2307: Cannot find module './types.js' or its corresponding type declarations.

1 import { type InitMainOptions } from './types.js';

node_modules/electron-audio-loopback/dist/renderer.d.ts:1:57 - error TS2307: Cannot find module './types.js' or its corresponding type declarations.

1 import { type GetLoopbackAudioMediaStreamOptions } from './types.js';
                                                          ~~~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  node_modules/electron-audio-loopback/dist/main.d.ts:1
     1  node_modules/electron-audio-loopback/dist/renderer.d.ts:1
error Command failed with exit code 2.
```
Seems like the node_modules/electron-audio-loopback/dist/types.js declaration file is not include into the package
So I copy the types.d.ts from src/ to dist/ after build